### PR TITLE
refactor: physical settlement

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,7 @@ on:
       - master
   pull_request:
     branches:
-      - master
+      - "**"
 
 jobs:
   lint:

--- a/src/config/errors.sol
+++ b/src/config/errors.sol
@@ -50,9 +50,6 @@ error GP_BadPhysicalSettlementToken();
 /// @dev burn or mint can only be called by corresponding engine.
 error GP_NotAuthorizedEngine();
 
-/// @dev cannot exercise more token than were issued
-error GP_ExceedsIssuedTokens();
-
 /* ---------------------------- *
  *   Common BaseEngine Errors   *
  * ---------------------------  */

--- a/src/config/types.sol
+++ b/src/config/types.sol
@@ -69,12 +69,10 @@ struct AssetDetail {
  * @param payout amount paid total
  */
 struct Settlement {
-    address engine;
+    address engine; //todo: can be removed if we encode exercise window in tokenId
     uint8 debtId;
-    // uint256 debtPerToken;
     uint256 debt;
     uint8 payoutId;
-    // uint256 payoutPerToken;
     uint256 payout;
 }
 
@@ -87,8 +85,6 @@ struct Settlement {
 struct PhysicalSettlementTracker {
     uint64 issued;
     uint64 exercised;
-    // address debtAsset;
-    // address collateralAsset;
     uint256 totalDebt;
     uint256 totalCollateralPaid;
 }

--- a/src/config/types.sol
+++ b/src/config/types.sol
@@ -84,7 +84,11 @@ struct Settlement {
  * @param issued number of tokens mints
  * @param exercised amount exercised within settlement window
  */
-struct TokenTracker {
+struct PhysicalSettlementTracker {
     uint64 issued;
     uint64 exercised;
+    // address debtAsset;
+    // address collateralAsset;
+    uint256 totalDebt;
+    uint256 totalCollateralPaid;
 }

--- a/src/config/types.sol
+++ b/src/config/types.sol
@@ -71,10 +71,10 @@ struct AssetDetail {
 struct Settlement {
     address engine;
     uint8 debtId;
-    uint256 debtPerToken;
+    // uint256 debtPerToken;
     uint256 debt;
     uint8 payoutId;
-    uint256 payoutPerToken;
+    // uint256 payoutPerToken;
     uint256 payout;
 }
 

--- a/src/config/types.sol
+++ b/src/config/types.sol
@@ -84,7 +84,6 @@ struct Settlement {
  */
 struct PhysicalSettlementTracker {
     uint64 issued;
-    uint64 exercised;
-    uint256 totalDebt;
-    uint256 totalCollateralPaid;
+    uint80 totalDebt;
+    uint80 totalPaid;
 }

--- a/src/core/Grappa.sol
+++ b/src/core/Grappa.sol
@@ -496,20 +496,14 @@ contract Grappa is OwnableUpgradeable, ReentrancyGuardUpgradeable, UUPSUpgradeab
 
         emit OptionSettled(_account, _tokenId, _amount, settlement.debt, settlement.payout);
 
-        IPhysicalSettlement engine = IPhysicalSettlement(settlement.engine);
-
-        // todo: encode settlement windoow
         if (settlement.debt > 0) {
-            engine.handleExercise(
-                _tokenId,
-                _amount, // amount exercised
-                assets[settlement.debtId].addr, // will be transfer to engine
-                settlement.debt, // amount transfer to engine
-                msg.sender, // get debt asset from from
-                assets[settlement.payoutId].addr,
-                settlement.payout,
-                _account
-            );
+            IPhysicalSettlement engine = IPhysicalSettlement(settlement.engine);
+
+            engine.handleExercise(_tokenId, settlement.debt, settlement.payout);
+            // pull debt asset from msg.sender to engine
+            engine.receiveDebtValue(assets[settlement.debtId].addr, msg.sender, settlement.debt);
+            // make the engine pay out payout amount
+            engine.sendPayoutValue(assets[settlement.payoutId].addr, _account, settlement.payout);
         }
 
         return (settlement.debt, settlement.payout);

--- a/src/core/Grappa.sol
+++ b/src/core/Grappa.sol
@@ -80,9 +80,6 @@ contract Grappa is OwnableUpgradeable, ReentrancyGuardUpgradeable, UUPSUpgradeab
     /// @dev address => oracleId
     mapping(address => uint8) public oracleIds;
 
-    /// @dev token => TokenTracker
-    // mapping(uint256 => TokenTracker) public tokenTracker;
-
     /*///////////////////////////////////////////////////////////////
                                 Events
     //////////////////////////////////////////////////////////////*/
@@ -245,9 +242,7 @@ contract Grappa is OwnableUpgradeable, ReentrancyGuardUpgradeable, UUPSUpgradeab
      * @param _tokenIds array of tokenIds to burn
      * @param _amounts array of amounts to burn
      */
-    function batchSettle(address _account, uint256[] memory _tokenIds, uint256[] memory _amounts) external nonReentrant 
-    // returns (Balance[] memory debts, Balance[] memory payouts)
-    {
+    function batchSettle(address _account, uint256[] memory _tokenIds, uint256[] memory _amounts) external nonReentrant {
         if (_tokenIds.length != _amounts.length) revert GP_WrongArgumentLength();
 
         optionToken.batchBurnGrappaOnly(_account, _tokenIds, _amounts);

--- a/src/core/Grappa.sol
+++ b/src/core/Grappa.sol
@@ -248,7 +248,7 @@ contract Grappa is OwnableUpgradeable, ReentrancyGuardUpgradeable, UUPSUpgradeab
     function batchSettle(address _account, uint256[] memory _tokenIds, uint256[] memory _amounts) external nonReentrant 
     // returns (Balance[] memory debts, Balance[] memory payouts)
     {
-        // (debts, payouts) = getBatchSettlement(_tokenIds, _amounts);
+        if (_tokenIds.length != _amounts.length) revert GP_WrongArgumentLength();
 
         optionToken.batchBurnGrappaOnly(_account, _tokenIds, _amounts);
 
@@ -621,7 +621,7 @@ contract Grappa is OwnableUpgradeable, ReentrancyGuardUpgradeable, UUPSUpgradeab
 
         // settlement window closed: you get nothing
         IPhysicalSettlement engine = IPhysicalSettlement(engines[engineId]);
-        if (block.timestamp > expiry + engine.getSettlementWindow()) return settlement;
+        if (block.timestamp >= expiry + engine.getSettlementWindow()) return settlement;
 
         // puts can only be collateralized in strike
         uint256 strikeAmount = uint256(strikePrice).convertDecimals(UNIT_DECIMALS, assets[strikeId].decimals);

--- a/src/core/Grappa.sol
+++ b/src/core/Grappa.sol
@@ -306,7 +306,7 @@ contract Grappa is OwnableUpgradeable, ReentrancyGuardUpgradeable, UUPSUpgradeab
                 payoutId = settlement.payoutId;
                 payout = settlement.payout;
 
-                if (settlement.debt != 0) {
+                if (settlement.debt > 0) {
                     debts = _addToBalances(debts, settlement.debtId, settlement.debt);
                 }
             }

--- a/src/core/engines/cross-margin/CrossMarginEngine.sol
+++ b/src/core/engines/cross-margin/CrossMarginEngine.sol
@@ -272,12 +272,11 @@ contract CrossMarginEngine is
      * @dev     this update the account storage
      */
     function _settle(address _subAccount) internal override {
-        // update the account in state
+        // todo: add which longs to settle, add returned data to a new event
+        accounts[_subAccount].settleLongAtExpiry(grappa, _getSettlementWindow());
+
         (Balance[] memory shortDebts, Balance[] memory shortPayouts) =
             accounts[_subAccount].settleShortAtExpiry(IPhysicalSettlement(address(this)), _getSettlementWindow());
-
-        // todo: add which longs to settle
-        accounts[_subAccount].settleLongAtExpiry(grappa, _getSettlementWindow());
         emit AccountSettled(_subAccount, shortDebts, shortPayouts);
     }
 

--- a/src/core/engines/cross-margin/CrossMarginEngine.sol
+++ b/src/core/engines/cross-margin/CrossMarginEngine.sol
@@ -179,18 +179,18 @@ contract CrossMarginEngine is
         if (!_isAccountAboveWater(_subAccount)) revert BM_AccountUnderwater();
     }
 
-    /**
-     * @notice payout to user on settlement.
-     * @dev this can only triggered by Grappa, would only be called on settlement.
-     * @param _asset asset to transfer
-     * @param _sender sender of debt
-     * @param _amount amount
-     */
-    function receiveDebtValue(address _asset, address _sender, uint256 _amount) external virtual {
-        _checkPermissioned(_sender);
+    // /**
+    //  * @notice payout to user on settlement.
+    //  * @dev this can only triggered by Grappa, would only be called on settlement.
+    //  * @param _asset asset to transfer
+    //  * @param _sender sender of debt
+    //  * @param _amount amount
+    //  */
+    // function receiveDebtValue(address _asset, address _sender, uint256 _amount) external virtual {
+    //     _checkPermissioned(_sender);
 
-        _receiveDebtValue(_asset, _sender, _amount);
-    }
+    //     _receiveDebtValue(_asset, _sender, _amount);
+    // }
 
     /**
      * @notice payout to user on settlement.
@@ -199,10 +199,7 @@ contract CrossMarginEngine is
      * @param _recipient receiver
      * @param _amount amount
      */
-    function sendPayoutValue(address _asset, address _recipient, uint256 _amount)
-        external
-        override (ICashSettlement)
-    {
+    function sendPayoutValue(address _asset, address _recipient, uint256 _amount) external override(ICashSettlement) {
         _checkPermissioned(_recipient);
 
         _sendPayoutValue(_asset, _recipient, _amount);
@@ -290,7 +287,7 @@ contract CrossMarginEngine is
      * ========================================================= *
      */
 
-    function _mintOption(address _subAccount, bytes calldata _data) internal override (BaseEngine, PhysicalSettlement) {
+    function _mintOption(address _subAccount, bytes calldata _data) internal override(BaseEngine, PhysicalSettlement) {
         // ensuring physical options are properly created
         PhysicalSettlement._mintOption(_subAccount, _data);
     }
@@ -298,12 +295,12 @@ contract CrossMarginEngine is
     function _mintOptionIntoAccount(address _subAccount, bytes calldata _data)
         internal
         virtual
-        override (BaseEngine, PhysicalSettlement)
+        override(BaseEngine, PhysicalSettlement)
     {
         PhysicalSettlement._mintOptionIntoAccount(_subAccount, _data);
     }
 
-    function _burnOption(address _subAccount, bytes calldata _data) internal virtual override (BaseEngine, PhysicalSettlement) {
+    function _burnOption(address _subAccount, bytes calldata _data) internal virtual override(BaseEngine, PhysicalSettlement) {
         PhysicalSettlement._burnOption(_subAccount, _data);
     }
 

--- a/src/core/engines/cross-margin/CrossMarginEngine.sol
+++ b/src/core/engines/cross-margin/CrossMarginEngine.sol
@@ -179,18 +179,18 @@ contract CrossMarginEngine is
         if (!_isAccountAboveWater(_subAccount)) revert BM_AccountUnderwater();
     }
 
-    // /**
-    //  * @notice payout to user on settlement.
-    //  * @dev this can only triggered by Grappa, would only be called on settlement.
-    //  * @param _asset asset to transfer
-    //  * @param _sender sender of debt
-    //  * @param _amount amount
-    //  */
-    // function receiveDebtValue(address _asset, address _sender, uint256 _amount) external virtual {
-    //     _checkPermissioned(_sender);
+    /**
+     * @notice payout to user on settlement.
+     * @dev this can only triggered by Grappa, would only be called on settlement.
+     * @param _asset asset to transfer
+     * @param _sender sender of debt
+     * @param _amount amount
+     */
+    function receiveDebtValue(address _asset, address _sender, uint256 _amount) external virtual {
+        _checkPermissioned(_sender);
 
-    //     _receiveDebtValue(_asset, _sender, _amount);
-    // }
+        _receiveDebtValue(_asset, _sender, _amount);
+    }
 
     /**
      * @notice payout to user on settlement.

--- a/src/core/engines/cross-margin/CrossMarginEngine.sol
+++ b/src/core/engines/cross-margin/CrossMarginEngine.sol
@@ -48,7 +48,6 @@ import "../../../config/errors.sol";
  */
 contract CrossMarginEngine is
     IMarginEngine,
-    ICashSettlement,
     BaseEngine,
     PhysicalSettlement,
     OwnableUpgradeable,
@@ -199,7 +198,7 @@ contract CrossMarginEngine is
      * @param _recipient receiver
      * @param _amount amount
      */
-    function sendPayoutValue(address _asset, address _recipient, uint256 _amount) external override(ICashSettlement) {
+    function sendPayoutValue(address _asset, address _recipient, uint256 _amount) external {
         _checkPermissioned(_recipient);
 
         _sendPayoutValue(_asset, _recipient, _amount);
@@ -276,7 +275,7 @@ contract CrossMarginEngine is
         accounts[_subAccount].settleLongAtExpiry(grappa, _getSettlementWindow());
 
         (Balance[] memory shortDebts, Balance[] memory shortPayouts) =
-            accounts[_subAccount].settleShortAtExpiry(IPhysicalSettlement(address(this)), _getSettlementWindow());
+            accounts[_subAccount].settleShortAtExpiry(_getSettlementWindow());
         emit AccountSettled(_subAccount, shortDebts, shortPayouts);
     }
 

--- a/src/core/engines/cross-margin/CrossMarginLib.sol
+++ b/src/core/engines/cross-margin/CrossMarginLib.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import {IGrappa} from "../../../interfaces/IGrappa.sol";
 import {IOracle} from "../../../interfaces/IOracle.sol";
+import {IPhysicalSettlement} from "../../../interfaces/IPhysicalSettlement.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 
 import "../../../libraries/TokenIdUtil.sol";
@@ -143,19 +144,28 @@ library CrossMarginLib {
 
     ///@dev Settles the accounts longs and shorts
     ///@param account CrossMarginAccount storage that will be updated in-place
-    function settleAtExpiry(CrossMarginAccount storage account, IGrappa grappa, uint256 settlementWindow)
+    function settleLongAtExpiry(CrossMarginAccount storage account, IGrappa grappa, uint256 settlementWindow)
         external
         returns (
             Balance[] memory longDebts,
-            Balance[] memory longPayouts,
-            Balance[] memory shortDebts,
-            Balance[] memory shortPayouts
+            Balance[] memory longPayouts
         )
     {
         // settling longs first as they can only increase collateral
         (longDebts, longPayouts) = _settleLongs(grappa, account, settlementWindow);
+    }
+
+    ///@dev Settles the accounts longs and shorts
+    ///@param account CrossMarginAccount storage that will be updated in-place
+    function settleShortAtExpiry(CrossMarginAccount storage account, IPhysicalSettlement engine, uint256 settlementWindow)
+        external
+        returns (
+            Balance[] memory shortDebts,
+            Balance[] memory shortPayouts
+        )
+    {
         // settling shorts last as they can only reduce collateral
-        (shortDebts, shortPayouts) = _settleShorts(grappa, account, settlementWindow);
+        (shortDebts, shortPayouts) = _settleShorts(engine, account, settlementWindow);
     }
 
     ///@dev Settles the accounts longs, adding collateral to balances
@@ -165,11 +175,10 @@ library CrossMarginLib {
         public
         returns (Balance[] memory debts, Balance[] memory payouts)
     {
-        uint256 i;
         uint256[] memory tokenIds;
         uint256[] memory amounts;
 
-        while (i < account.longs.length) {
+        for (uint256 i; i < account.longs.length; ) {
             uint256 tokenId = account.longs[i].tokenId;
 
             (, SettlementType settlementType,, uint64 expiry,,) = tokenId.parseTokenId();
@@ -188,57 +197,49 @@ library CrossMarginLib {
 
                 account.longs.removeAt(i);
             } else {
-                unchecked {
-                    ++i;
-                }
+                unchecked { ++i; }
             }
         }
 
         if (tokenIds.length > 0) {
-            // debts is what was sent to the issuer of a physical option
-            // payouts is the collateral that the option was settled for
-            // debts[i] > 0 for physical settled options
-            // debts[i] = 0 for cash settled options
-            // payouts[i] = 0 for OTM cash settled,
-            // payouts[i] > 0 for physical settled options
-            (debts, payouts) = grappa.batchSettle(address(this), tokenIds, amounts);
+            // todo: only settle selected ids
+            (debts, payouts) = grappa.getBatchSettlement(tokenIds, amounts);
+            
+            grappa.batchSettle(address(this), tokenIds, amounts);
 
-            for (i = 0; i < debts.length;) {
+            for (uint256 i; i < debts.length;) {
                 if (debts[i].amount != 0) {
                     // remove the collateral in the account storage.
                     removeCollateral(account, debts[i].collateralId, debts[i].amount);
                 }
-
-                unchecked {
-                    ++i;
-                }
+                unchecked { ++i; }
             }
-
-            for (i = 0; i < payouts.length;) {
+            for(uint256 i; i < payouts.length; ) {
                 if (payouts[i].amount != 0) {
-                    // add the collateral in the account storage.
+                    // add to collateral in the account storage.
                     addCollateral(account, payouts[i].collateralId, payouts[i].amount);
                 }
 
-                unchecked {
-                    ++i;
-                }
+                unchecked { ++i; }
             }
         }
     }
 
     ///@dev Settles the accounts shorts, reserving collateral for ITM options
-    ///@param grappa interface to get short option payouts in a batch call
+    ///@param engine interface to get short option payouts in a batch call
     ///@param account CrossMarginAccount memory that will be updated in-place
-    function _settleShorts(IGrappa grappa, CrossMarginAccount storage account, uint256 settlementWindow)
+    function _settleShorts(
+        IPhysicalSettlement engine, 
+        CrossMarginAccount storage account,
+        uint256 settlementWindow
+    )
         public
         returns (Balance[] memory debts, Balance[] memory payouts)
     {
-        uint256 i;
         uint256[] memory tokenIds;
         uint256[] memory amounts;
 
-        while (i < account.shorts.length) {
+        for (uint256 i = 0; i < account.shorts.length; ) {
             uint256 tokenId = account.shorts[i].tokenId;
 
             (, SettlementType settlementType,, uint64 expiry,,) = tokenId.parseTokenId();
@@ -254,45 +255,33 @@ library CrossMarginLib {
             if (block.timestamp >= expiry && canSettle) {
                 tokenIds = tokenIds.append(tokenId);
                 amounts = amounts.append(account.shorts[i].amount);
-
                 account.shorts.removeAt(i);
-            } else {
-                unchecked {
-                    ++i;
-                }
             }
+            
+            unchecked { ++i; }
+            
         }
 
         if (tokenIds.length > 0) {
-            // debts is what was sent to the issuer of a physical option
-            // payouts is the collateral that the option was settled for
-            // debts[i] > 0 for physical settled options
-            // debts[i] = 0 for cash settled options
-            // payouts[i] = 0 for OTM cash settled,
-            // payouts[i] > 0 for physical settled options
-            (debts, payouts) = grappa.getBatchSettlement(tokenIds, amounts);
-
-            for (i = 0; i < debts.length;) {
-                if (debts[i].amount != 0) {
-                    // add the collateral in the account storage.
-                    addCollateral(account, debts[i].collateralId, debts[i].amount);
-                }
-
-                unchecked {
-                    ++i;
-                }
-            }
-
-            for (i = 0; i < payouts.length;) {
+            // the engine will socialized the debt and payout for physical settled options
+            (debts, payouts) = engine.getBatchSettlementForShorts(tokenIds, amounts);
+            
+            for (uint256 i = 0; i < payouts.length;) {
                 if (payouts[i].amount != 0) {
                     // remove the collateral in the account storage.
                     removeCollateral(account, payouts[i].collateralId, payouts[i].amount);
                 }
+                unchecked { ++i; }
+            }
 
-                unchecked {
-                    ++i;
+            for (uint256 i = 0; i < debts.length;) {
+                if (debts[i].amount != 0) {
+                    // add to what is paid from exerciser
+                    addCollateral(account, debts[i].collateralId, debts[i].amount);
                 }
+                unchecked { ++i; }
             }
         }
     }
+
 }

--- a/src/core/engines/mixins/PhysicalSettlement.sol
+++ b/src/core/engines/mixins/PhysicalSettlement.sol
@@ -61,7 +61,7 @@ abstract contract PhysicalSettlement is BaseEngine {
         for (uint256 i; i < _tokenIds.length;) {
             PhysicalSettlementTracker memory tracker = tokenTracker[_tokenIds[i]];
 
-            // if the token is physical settled and someone exercised prior to exercise window
+            // if the token is physical settled and someone exercised within exercise window
             // we socialized the payout and debt (total amount paid out and received during exercise window)
             if (tracker.totalDebt > 0) {
                 (Balance memory debt, Balance memory payout) = _socializeSettlement(tracker, _tokenIds[i], _amounts[i]);
@@ -91,7 +91,7 @@ abstract contract PhysicalSettlement is BaseEngine {
             payout.collateralId = strikeId;
         }
         debt.amount = (tracker.totalDebt * shortAmount / tracker.issued).toUint80();
-        payout.amount = (tracker.totalCollateralPaid * shortAmount / tracker.issued).toUint80();
+        payout.amount = (tracker.totalPaid * shortAmount / tracker.issued).toUint80();
     }
 
     /**
@@ -99,8 +99,8 @@ abstract contract PhysicalSettlement is BaseEngine {
      */
     function handleExercise(uint256 _tokenId, uint256 _debtPaid, uint256 _amountPaidOut) external {
         _checkIsGrappa();
-        tokenTracker[_tokenId].totalDebt += _debtPaid;
-        tokenTracker[_tokenId].totalCollateralPaid += _amountPaidOut;
+        tokenTracker[_tokenId].totalDebt += _debtPaid.toUint80();
+        tokenTracker[_tokenId].totalPaid += _amountPaidOut.toUint80();
     }
 
     /**

--- a/src/core/engines/mixins/PhysicalSettlement.sol
+++ b/src/core/engines/mixins/PhysicalSettlement.sol
@@ -98,6 +98,7 @@ abstract contract PhysicalSettlement is BaseEngine {
      * @dev hook to be invoked by Grappa to handle custom logic of settlement
      */
     function handleExercise(uint256 _tokenId, uint256 _debtPaid, uint256 _amountPaidOut) external {
+        _checkIsGrappa();
         tokenTracker[_tokenId].totalDebt += _debtPaid;
         tokenTracker[_tokenId].totalCollateralPaid += _amountPaidOut;
     }

--- a/src/core/engines/mixins/PhysicalSettlement.sol
+++ b/src/core/engines/mixins/PhysicalSettlement.sol
@@ -81,17 +81,13 @@ abstract contract PhysicalSettlement is BaseEngine {
 
         if (tokenType == TokenType.CALL) {
             debt.collateralId = strikeId;
-            debt.amount = (tracker.totalDebt * shortAmount / tracker.issued).toUint80();
-
             payout.collateralId = underlyingId;
-            payout.amount = (tracker.totalCollateralPaid * shortAmount / tracker.issued).toUint80();
         } else if (tokenType == TokenType.PUT) {
             debt.collateralId = underlyingId;
-            debt.amount = (tracker.totalCollateralPaid * shortAmount / tracker.issued).toUint80();
-
             payout.collateralId = strikeId;
-            payout.amount = (tracker.totalDebt * shortAmount / tracker.issued).toUint80();
         }
+        debt.amount = (tracker.totalDebt * shortAmount / tracker.issued).toUint80();
+        payout.amount = (tracker.totalCollateralPaid * shortAmount / tracker.issued).toUint80();
     }
 
     function handleExercise(

--- a/src/interfaces/IGrappa.sol
+++ b/src/interfaces/IGrappa.sol
@@ -68,5 +68,4 @@ interface IGrappa {
         external
         view
         returns (Balance[] memory debts, Balance[] memory payouts);
-
 }

--- a/src/interfaces/IGrappa.sol
+++ b/src/interfaces/IGrappa.sol
@@ -57,9 +57,7 @@ interface IGrappa {
      * @param _tokenIds array of tokenIds to burn
      * @param _amounts array of amounts to burn
      */
-    function batchSettle(address _account, uint256[] memory _tokenIds, uint256[] memory _amounts)
-        external
-        returns (Balance[] memory debts, Balance[] memory payouts);
+    function batchSettle(address _account, uint256[] memory _tokenIds, uint256[] memory _amounts) external;
 
     /**
      * @notice calculate array of tokens settlement at expiry
@@ -71,12 +69,4 @@ interface IGrappa {
         view
         returns (Balance[] memory debts, Balance[] memory payouts);
 
-    /**
-     * @notice registers a new issuance of a physical settled token
-     * @dev if isMinted is false, it will deduct the issuance
-     * @param _tokenId physical token id
-     * @param _update amount thats changed
-     * @param _isMint was minted or burned
-     */
-    function trackTokenIssuance(uint256 _tokenId, uint64 _update, bool _isMint) external;
 }

--- a/src/interfaces/IPhysicalSettlement.sol
+++ b/src/interfaces/IPhysicalSettlement.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {Settlement} from "../config/types.sol";
+import {Settlement, Balance} from "../config/types.sol";
 
 interface IPhysicalSettlement {
     function receiveDebtValue(address _asset, address _recipient, uint256 _amount) external;
@@ -11,4 +11,12 @@ interface IPhysicalSettlement {
     function getSettlementWindow() external view returns (uint256 window);
 
     function setSettlementWindow(uint256 _window) external;
+
+    /**
+     * how the short should be settled
+     */
+    function getBatchSettlementForShorts(uint256 [] calldata _tokenIds, uint256[] calldata _amounts) external view returns (
+        Balance[] memory debts, 
+        Balance[] memory payouts
+    );
 }

--- a/src/interfaces/IPhysicalSettlement.sol
+++ b/src/interfaces/IPhysicalSettlement.sol
@@ -4,20 +4,11 @@ pragma solidity ^0.8.0;
 import {Settlement, Balance} from "../config/types.sol";
 
 interface IPhysicalSettlement {
-    function handleExercise(
-        uint256 _tokenExercised,
-        uint256 _tokenid,
-        address _inAsset,
-        uint256 _inAmount,
-        address _from,
-        address _toAsset,
-        uint256 _toAmount,
-        address _to
-    ) external;
+    function handleExercise(uint256 _tokenid, uint256 _debtAmount, uint256 _payoutAmount) external;
 
-    // function receiveDebtValue(address _asset, address _recipient, uint256 _amount) external;
+    function receiveDebtValue(address _asset, address _recipient, uint256 _amount) external;
 
-    // function sendPayoutValue(address _asset, address _recipient, uint256 _amount) external;
+    function sendPayoutValue(address _asset, address _recipient, uint256 _amount) external;
 
     function getSettlementWindow() external view returns (uint256 window);
 

--- a/src/interfaces/IPhysicalSettlement.sol
+++ b/src/interfaces/IPhysicalSettlement.sol
@@ -12,8 +12,6 @@ interface IPhysicalSettlement {
 
     function getSettlementWindow() external view returns (uint256 window);
 
-    function setSettlementWindow(uint256 _window) external;
-
     /**
      * how the short should be settled
      */

--- a/src/interfaces/IPhysicalSettlement.sol
+++ b/src/interfaces/IPhysicalSettlement.sol
@@ -4,9 +4,20 @@ pragma solidity ^0.8.0;
 import {Settlement, Balance} from "../config/types.sol";
 
 interface IPhysicalSettlement {
-    function receiveDebtValue(address _asset, address _recipient, uint256 _amount) external;
+    function handleExercise(
+        uint256 _tokenExercised,
+        uint256 _tokenid,
+        address _inAsset,
+        uint256 _inAmount,
+        address _from,
+        address _toAsset,
+        uint256 _toAmount,
+        address _to
+    ) external;
 
-    function sendPayoutValue(address _asset, address _recipient, uint256 _amount) external;
+    // function receiveDebtValue(address _asset, address _recipient, uint256 _amount) external;
+
+    // function sendPayoutValue(address _asset, address _recipient, uint256 _amount) external;
 
     function getSettlementWindow() external view returns (uint256 window);
 
@@ -15,8 +26,8 @@ interface IPhysicalSettlement {
     /**
      * how the short should be settled
      */
-    function getBatchSettlementForShorts(uint256 [] calldata _tokenIds, uint256[] calldata _amounts) external view returns (
-        Balance[] memory debts, 
-        Balance[] memory payouts
-    );
+    function getBatchSettlementForShorts(uint256[] calldata _tokenIds, uint256[] calldata _amounts)
+        external
+        view
+        returns (Balance[] memory debts, Balance[] memory payouts);
 }

--- a/src/test/engine-integrations/cross-margin/SettleCashOption.t.sol
+++ b/src/test/engine-integrations/cross-margin/SettleCashOption.t.sol
@@ -401,7 +401,7 @@ contract TestSettleCashLongShort_CM is CrossMarginFixture {
         engine.execute(address(this), selfActions);
 
         // expire option & set expiry price
-        vm.warp(expiry + engine.getSettlementWindow() + 1);
+        vm.warp(expiry + engine.getSettlementWindow());
         oracle.setExpiryPrice(address(weth), address(usdc), 1000 * UNIT);
 
         //settle option

--- a/src/test/engine-integrations/cross-margin/SettleCashOption.t.sol
+++ b/src/test/engine-integrations/cross-margin/SettleCashOption.t.sol
@@ -401,7 +401,7 @@ contract TestSettleCashLongShort_CM is CrossMarginFixture {
         engine.execute(address(this), selfActions);
 
         // expire option & set expiry price
-        vm.warp(expiry + engine.getSettlementWindow());
+        vm.warp(expiry + engine.getSettlementWindow() + 1);
         oracle.setExpiryPrice(address(weth), address(usdc), 1000 * UNIT);
 
         //settle option


### PR DESCRIPTION
## Summary

This PR fix 2 design flaws 
### 1. The definition of function `Grappa.getSettlement`

The definition in the previous PR (#201) for physical settled option is flawed. The meaning of the returned value should be "how much is 1 long option token worth".  Intuitively, this number should be (0, 0) after the settlement window is closed, meaning your token is worthless.  But in the last PR, this definition was changed to: 
* before settlement windows close, it returns how much `payout` you can get by paying out `debt`. 
* after settlement window, it returns: **how much underlying and collateral were exchanged during exercise window, proportional to 1 option token.**

This was added in just for ease of the short side to calculate if they want to socialised the losses, but it change the fundamental purpose of the function. When time pass the exercise window, this function change from "serving the long token", to "serving the short token", which is a design flaw.

The workaround is to have a custom `getBatchSettlementForShorts` implementation in `PhysicalSettlement`, that translate the "settlement payout for long" to "settlement for shorts": 
* for cash settled asset: each short position should be translated into loss of `payout`. 
* for physical settled asset: each short position is convert to proportional of total exercised amount.  

### 2. Ambiguous Mint flow and contract logic separation
* Before physical settled options, the mint (seller) flow is always engine => OptionToken. `Grappa` as a contract is not meant to be used as storage to store total mint / burn ..etc. 
* In the previous PR, the `tracker` is introduced and create a new function for engine to track how much is minted, and also used during exercise. By the very easy principle of logic separation: Grappa should only be used as registry and check of tokenId validness, this logic should not be there.
* The purpose of this logic is actually to serve the previous functionality: record how much long is exercised so we can socialized to the short side. As a result this should be belong to `PhysicalSettlement` inside each engine to implement.
* This is done by adding a `handleExerciseHook` to inform the engine what is exercised.

## Todo
- [ ] encode exercise window into tokenIds

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Add [natspec](https://docs.soliditylang.org/en/latest/natspec-format.html) for all functions / parameters
- [ ] Ran `forge snapshot`
- [ ] Ran `forge fmt`
- [x] Ran `forge test`
- [ ] [Triage Slither issues](../README.md#triage-issues), and post uncertain ones in the PR
